### PR TITLE
fix: コメントの描画バグを修正

### DIFF
--- a/src/infra/cache/UserViewStore.ts
+++ b/src/infra/cache/UserViewStore.ts
@@ -19,7 +19,7 @@ export const useUserViewStore = create<UserViewState>((set, get) => ({
   views: {},
   setComment: (id, comment) => {
     const now = Date.now();
-    const until = now + 5000;
+    const until = now + 2500;
     set((state) => {
       const prev = state.views[id] ?? {
         id,


### PR DESCRIPTION
- #2 

 **バグの根本原因**:
  - コメント期限（5秒）がフェードアウト開始（3秒）より後
  - t=5秒でclearExpiredCommentsが実行され、削除済みのviewに状態更新が発生
  - CSSアニメーションとUserCardフェードアウトの競合

**修正内容**
     コメント表示期限を5秒→2.5秒に短縮し、フェードアウト開始（3秒）前に確実にクリアする

### 確認内容
- [x] 実際にUI上でコメントのちらつきがなくなったことを確認